### PR TITLE
Store the author name

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -35,6 +35,7 @@ module.exports = generators.Base.extend({
       type: 'input',
       name: 'author',
       message: 'Author name?',
+      store: true,
       default: ''
     }], function (answers) {
       that._name = answers.name;


### PR DESCRIPTION
The `store` option will make sure that, after typing it once, that option will get stored on the user's computer so they never have to type it again :tada: 

(introduced in yeoman-generator 0.18)

Ref https://github.com/yeoman/generator/releases/tag/v0.18.0 
