### PR TITLE
Use `installDependencies` to install dependencies

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -54,9 +54,9 @@ module.exports = generators.Base.extend({
     this.fs.move(this.destinationPath('.npmignore'), this.destinationPath('.gitignore'));
   },
 
-  installDependencies: function() {
+  install: function() {
     if (this._deps) {
-      this.npmInstall();
+      this.installDependencies({bower: false});
     }
   }
 });


### PR DESCRIPTION
Currently the generator used `this. npmInstall` to install dependencies. It's better to use `installDependencies` as that one shows a message to the user about what's happening and what users should do when it goes wrong.
