### PR TITLE
Change dependency protocol for appx-starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/MicrosoftEdge/generator-appx.git"
+    "url": "https://github.com/MicrosoftEdge/generator-appx.git"
   },
   "dependencies": {
-    "appx-starter": "git://github.com/MicrosoftEdge/appx-starter",
+    "appx-starter": "https://github.com/MicrosoftEdge/appx-starter",
     "yeoman-generator": "^0.20.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Many work environments have port 9148 (required for the git:// protocol) closed which breaks installing generator-appx
